### PR TITLE
Improvement for section

### DIFF
--- a/api/content/models/Content.settings.json
+++ b/api/content/models/Content.settings.json
@@ -13,6 +13,9 @@
       "type": "string",
       "required": true
     },
+    "text": {
+      "type": "richtext"
+    },
     "sections": {
       "type": "component",
       "repeatable": true,

--- a/api/content/models/Content.settings.json
+++ b/api/content/models/Content.settings.json
@@ -13,12 +13,14 @@
       "type": "string",
       "required": true
     },
-    "text": {
-      "type": "richtext",
-      "required": true
-    },
     "subcontents": {
       "collection": "content"
+    },
+    "sections": {
+      "type": "component",
+      "repeatable": true,
+      "component": "page-plugin.repeat-content",
+      "required": true
     }
   }
 }

--- a/components/page-plugin/repeat-content.json
+++ b/components/page-plugin/repeat-content.json
@@ -10,9 +10,9 @@
     "describe": {
       "type": "richtext"
     },
-    "sectionId": {
+    "sectionTitle": {
       "type": "string",
-      "required": true,
+      "required": false,
       "unique": true
     },
     "hidden": {

--- a/components/page-plugin/repeat-content.json
+++ b/components/page-plugin/repeat-content.json
@@ -1,0 +1,22 @@
+{
+  "connection": "default",
+  "collectionName": "components_page_plugin_repeat_contents",
+  "info": {
+    "name": "Repeat-Content",
+    "icon": "align-justify"
+  },
+  "options": {},
+  "attributes": {
+    "describe": {
+      "type": "richtext"
+    },
+    "sectionId": {
+      "type": "string",
+      "required": true,
+      "unique": true
+    },
+    "hidden": {
+      "type": "boolean"
+    }
+  }
+}


### PR DESCRIPTION
Added an easier way to add sections for every entry in the content section of the cms.

- Removed the text field
- Added a new repeatable component in content types for "content"
- added some subfields in that component called reapet-content

1. Test the new content fields
2.  Add new content
3.  Run it with corporate-ui-site with branch scania/corporate-ui-site#72 (improvement/section_for_cms)
4. Look at all the different templates used, e.g code, usage, colors and so on

You need my temp database for this since all templates and data are modified and use correct corporate-ui-site branch improvement/section_for_cms