### PR TITLE
Improvement/logotype page data

### DIFF
--- a/components/content-plugin/one-column.json
+++ b/components/content-plugin/one-column.json
@@ -1,4 +1,6 @@
 {
+  "connection": "default",
+  "collectionName": "components_content_plugin_one_columns",
   "info": {
     "name": "One Column",
     "icon": "bars"
@@ -11,7 +13,5 @@
     "Text": {
       "type": "richtext"
     }
-  },
-  "connection": "default",
-  "collectionName": "components_content_plugin_one_columns"
+  }
 }

--- a/components/content-plugin/right-image.json
+++ b/components/content-plugin/right-image.json
@@ -7,9 +7,6 @@
   },
   "options": {},
   "attributes": {
-    "text": {
-      "type": "richtext"
-    },
     "title": {
       "type": "string"
     },
@@ -18,10 +15,10 @@
       "repeatable": true,
       "component": "nested.images"
     },
-    "leftTextField": {
+    "Paragraphs": {
       "type": "component",
-      "repeatable": false,
-      "component": "nested.textfield"
+      "repeatable": true,
+      "component": "nested.columns"
     }
   }
 }

--- a/components/content-plugin/right-image.json
+++ b/components/content-plugin/right-image.json
@@ -10,14 +10,18 @@
     "text": {
       "type": "richtext"
     },
-    "image": {
-      "model": "file",
-      "via": "related",
-      "plugin": "upload",
-      "required": false
-    },
     "title": {
       "type": "string"
+    },
+    "Images": {
+      "type": "component",
+      "repeatable": true,
+      "component": "nested.images"
+    },
+    "leftTextField": {
+      "type": "component",
+      "repeatable": false,
+      "component": "nested.textfield"
     }
   }
 }

--- a/components/content-plugin/two-columns.json
+++ b/components/content-plugin/two-columns.json
@@ -10,12 +10,12 @@
     "Title": {
       "type": "string"
     },
-    "LeftColumn": {
+    "ParagraphLeft": {
       "type": "component",
       "repeatable": false,
       "component": "nested.textfield"
     },
-    "RightColumn": {
+    "ParagraphRight": {
       "type": "component",
       "repeatable": false,
       "component": "nested.textfield"

--- a/components/content-plugin/two-columns.json
+++ b/components/content-plugin/two-columns.json
@@ -1,4 +1,6 @@
 {
+  "connection": "default",
+  "collectionName": "components_content_plugin_two_columns",
   "info": {
     "name": "Two Columns",
     "icon": "th-large"
@@ -8,13 +10,15 @@
     "Title": {
       "type": "string"
     },
-    "leftColumn": {
-      "type": "richtext"
+    "LeftColumn": {
+      "type": "component",
+      "repeatable": false,
+      "component": "nested.textfield"
     },
-    "rightColumn": {
-      "type": "richtext"
+    "RightColumn": {
+      "type": "component",
+      "repeatable": false,
+      "component": "nested.textfield"
     }
-  },
-  "connection": "default",
-  "collectionName": "components_content_plugin_two_columns"
+  }
 }

--- a/components/nested/columns.json
+++ b/components/nested/columns.json
@@ -1,0 +1,22 @@
+{
+  "connection": "default",
+  "collectionName": "components_nested_columns",
+  "info": {
+    "name": "Columns",
+    "icon": "columns"
+  },
+  "options": {},
+  "attributes": {
+    "textfield": {
+      "type": "richtext"
+    },
+    "Columns": {
+      "type": "enumeration",
+      "enum": [
+        "One",
+        "Two",
+        "Three"
+      ]
+    }
+  }
+}

--- a/components/nested/images.json
+++ b/components/nested/images.json
@@ -1,0 +1,29 @@
+{
+  "connection": "default",
+  "collectionName": "components_nested_images",
+  "info": {
+    "name": "images",
+    "icon": "camera-retro"
+  },
+  "options": {},
+  "attributes": {
+    "image": {
+      "collection": "file",
+      "via": "related",
+      "plugin": "upload",
+      "required": false
+    },
+    "label": {
+      "type": "string"
+    },
+    "caption": {
+      "type": "string"
+    },
+    "negative": {
+      "type": "boolean"
+    },
+    "alternate": {
+      "type": "string"
+    }
+  }
+}

--- a/components/nested/textfield.json
+++ b/components/nested/textfield.json
@@ -10,7 +10,7 @@
     "textfield": {
       "type": "richtext"
     },
-    "Ingress": {
+    "Introduction": {
       "type": "boolean"
     }
   }

--- a/components/nested/textfield.json
+++ b/components/nested/textfield.json
@@ -10,7 +10,7 @@
     "textfield": {
       "type": "richtext"
     },
-    "lead": {
+    "Ingress": {
       "type": "boolean"
     }
   }

--- a/components/nested/textfield.json
+++ b/components/nested/textfield.json
@@ -1,0 +1,17 @@
+{
+  "connection": "default",
+  "collectionName": "components_nested_textfields",
+  "info": {
+    "name": "textfield",
+    "icon": "align-center"
+  },
+  "options": {},
+  "attributes": {
+    "textfield": {
+      "type": "richtext"
+    },
+    "lead": {
+      "type": "boolean"
+    }
+  }
+}


### PR DESCRIPTION
Ask for the correct data before testing this branch
This branch is used for scania/corporate-ui-site#100 logotype page PART 1

- Added three new nested components
  - Image (Possible too add caption, labels and negative background)
  - Text field (rich text and a ingress option)
  - columns (Possible to use for multiple columns)
- Updated two column template
- Updated right image template 

Note: This is for testing these options, left image template have not been updated, same with one column.

Merging this into a separate branch if other changes need to be done in the logotype page part 2

